### PR TITLE
Adjust link to search instead of messages

### DIFF
--- a/src/main/java/com/kongz/graylog/plugins/slack/SlackNotification.java
+++ b/src/main/java/com/kongz/graylog/plugins/slack/SlackNotification.java
@@ -301,7 +301,7 @@ public class SlackNotification implements EventNotification {
 		if (!baseUrl.endsWith("/")) {
 			builder.append('/');
 		}
-		return builder.append("streams/").append(stream.getId()).append("/messages?q=*&rangetype=relative&relative=3600")
+		return builder.append("streams/").append(stream.getId()).append("/search?q=&rangetype=relative&relative=3600")
 				.toString();
 	}
 


### PR DESCRIPTION
The link to the stream ends in `/messages`, which results in a "Page not found" in Gralog 5.1.2, whereas if the link ends in `/search`, the correct stream is displayed. In addition to that, the query with `*` results in the error
> Query parsing error: Cannot parse query, cause: '*' or '?' not allowed as first character in WildcardQuery.

With an empty query string, this works without a problem.